### PR TITLE
add: get userdata at DB, send daily alert/sunday alert, !help event

### DIFF
--- a/User/getuserdata.js
+++ b/User/getuserdata.js
@@ -1,0 +1,20 @@
+const mysql = require("mysql");
+const root = require("../db/dbrootInfo.js");
+
+const connection = mysql.createConnection(root);
+connection.connect();
+
+let userdata = function () {
+    return new Promise(function(resolve, reject) {
+        try{
+            connection.query("SELECT user_id, intra_id, on_off FROM user;",
+            function(error, results){
+                resolve(results);
+            });
+        } catch {
+            resolve(null);
+        }
+    });
+};
+
+module.exports = userdata;

--- a/Utils/sendmsg.js
+++ b/Utils/sendmsg.js
@@ -1,69 +1,108 @@
-const usersDataFunc = require("./getuserlist.js"); //getuserlist.js에서 start 함수 받아옴
 const { App } = require("@slack/bolt");
 const { signingSecret, token } = require("../db/token.js"); //module.exports = {signingSecret, token}
+const getuser = require("../User/getuserdata.js");
 
 const app = new App({ signingSecret, token });
 
-let sendMsg = async () => {
-    let usersData = await usersDataFunc();
+let dailyMsg = async () => {
+    const userdata = await getuser();
+    
+    if (userdata === undefined)
+        console.log("유저 데이터 가져오기 실패");
+    else {
+        let i;
 
-    if (usersData != undefined) {
-        //유저정보가 성공적으로 저장되어 있으면 실행
-        let usersIdList = usersData.usersIdList;
-        let usersStore = usersData.usersStore;
-
-        /*아래 forEach 부분을 스케줄링 함수 안에 넣어야할 것같아요*/
-        usersIdList.forEach((user) => {
-            console.log(usersStore[user]);
-            /*이 부분에 메세지 전송이 있으면 됩니다.*/
+        for (i = 0; i < userdata.length; i++)
+        {
             (async () => {
                 try {
-                    const result = await app.client.chat.postMessage({
-                        token, //process.env.SLACK_BOT_TOKEN,
-                        channel: user,
-                        blocks: [
-                            {
-                                type: "section",
-                                text: {
-                                    type: "plain_text",
-                                    text: "오늘 보고서 작성하셨나요?",
-                                    emoji: true,
+                    if (userdata[i].on_off == 1)
+                    {
+                        const result = await app.client.chat.postMessage({
+                            token, 
+                            channel: userdata[i].user_id,
+                            blocks: [
+                                {
+                                    type: "section",
+                                    text: {
+                                        type: "plain_text",
+                                        text: "오늘 보고서 작성하셨나요?",
+                                        emoji: true,
+                                    },
                                 },
-                            },
-                            {
-                                type: "actions",
-                                elements: [
-                                    {
-                                        type: "button",
-                                        text: {
-                                            type: "plain_text",
-                                            text: "네",
-                                            emoji: true,
+                                {
+                                    type: "actions",
+                                    elements: [
+                                        {
+                                            type: "button",
+                                            text: {
+                                                type: "plain_text",
+                                                text: "네",
+                                                emoji: true,
+                                            },
+                                            value: "yes_button",
+                                            action_id: "action_yes",
                                         },
-                                        value: "yes_button",
-                                        action_id: "action_yes",
-                                    },
-                                    {
-                                        type: "button",
-                                        text: {
-                                            type: "plain_text",
-                                            text: "아니요",
-                                            emoji: true,
+                                        {
+                                            type: "button",
+                                            text: {
+                                                type: "plain_text",
+                                                text: "아니요",
+                                                emoji: true,
+                                            },
+                                            value: "no_button",
+                                            action_id: "action_no",
                                         },
-                                        value: "no_button",
-                                        action_id: "action_no",
-                                    },
-                                ],
-                            },
-                        ],
-                    });
-                    console.log(result);
+                                    ],
+                                },
+                            ]
+                        });
+                        console.log(result);
+                    }
                 } catch (error) {
                     console.error(error);
                 }
             })();
-        });
+        }
     }
 };
 
-module.exports = sendMsg;
+let sundayMsg = async() => {
+    const userdata = await getuser();
+    
+    if (userdata === undefined)
+        console.log("유저 데이터 가져오기 실패");
+    else {
+        let i;
+
+        for (i = 0; i < userdata.length; i++)
+        {
+            (async () => {
+                try {
+                    if(userdata[i].on_off > 0)
+                    {
+                        const result = await app.client.chat.postMessage({
+                            token, 
+                            channel: userdata[i].user_id,
+                            blocks: [
+                                {
+                                    "type": "section",
+                                    "text": {
+                                        "type": "plain_text",
+                                        "text": "‼️‼️오늘은 보고서 마감일‼️‼️",
+                                        "emoji": true
+                                    }
+                                }
+                            ]
+                        });
+                        console.log(result);
+                    }
+                } catch(error) {
+                    console.error(error);
+                }
+            })();
+        }
+    }
+};
+
+module.exports = {dailyMsg, sundayMsg};

--- a/main.js
+++ b/main.js
@@ -234,9 +234,36 @@ app.message("!push state", async ({ body, say }) => {
     }
 });
 
+app.message("!help", async({body, say}) => {
+    try {
+        await say({
+            "blocks": [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "`!join`\n: 구독 시작\n`!delete`\n: 구독 취소"
+                    }
+                },{
+                    "type": "divider"
+                },{
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "`!push on`\n: 모든 알림 받기 (기본)\n`!push sun`\n: 마감일 알림만 받기\n`!push off`\n: 모든 알림 끄기\n`!push state`\n: 알림 상태 확인"
+                    }
+                }
+            ]
+        }); 
+    } catch(error) {
+        console.error(error);
+    }
+});
+
 (async () => {
     await app.start(process.env.PORT || 3000);
     //schedule.scheduleJob('37 15 * * *', function(){
-    //sendMsg();
+    sendMsg.sundayMsg();
+    sendMsg.dailyMsg();
     //});
 })();


### PR DESCRIPTION
1. `getuserdata.js\userdata` 추가
- user 테이블에서 모든 유저의 user_id와 intra_id, on_off를 반환하는 함수
- Promise로 작성되었기 때문에 비동기 형식으로 접근해야 합니다.

2. `sendmsg.js\dailyMsg`와 `sendmsg.js\sundayMsg` 추가
- 매일 발송하는 보고서 알림과 마감일 알림 분리
- main 함수에서 요일 확인 후 전송하도록 처리

3. `main.js`에 `app.message("!help",...)` 추가
- 유저가 `!help`를 요청할 경우 사용가능한 명령어 전송 
