### PR TITLE
일주일이 지난 후에 YES/NO 버튼 클릭 방지 기능 추가

### DIFF
--- a/Utils/getperiod.js
+++ b/Utils/getperiod.js
@@ -1,11 +1,11 @@
 const db = require('../db/dbconnection');
 
-let getPeriod = function () {
+let getPeriod = function (date) {
     return new Promise(function(resolve, reject) {
         try{
             db.query(`SELECT week
             FROM period
-            WHERE now() >= start_of_week AND now() <= end_of_week;`,
+            WHERE "${date}" >= start_of_week AND "${date}" <= end_of_week;`,
             function(error, results){
                 resolve(results[0].week);
             });

--- a/Utils/sendmsg.js
+++ b/Utils/sendmsg.js
@@ -3,8 +3,11 @@ const { signingSecret, token } = require("../db/token.js"); //module.exports = {
 const getUserData = require("../User/getuserdata.js");
 const getPeriod = require("./getperiod.js");
 const msgBlocks = require("./msgBlocks.json");
+const moment = require("moment");
 
 const app = new App({ signingSecret, token });
+
+moment.locale("ko");
 
 let dailyMsg = async () => {
     const userdata = await getUserData();
@@ -45,7 +48,8 @@ let dailyMsg = async () => {
 
 let sundayMsg = async () => {
     const userdata = await getUserData();
-    const week = await getPeriod();
+    let m = moment().format('YYYY-MM-DD HH:mm:ss');
+    const week = await getPeriod(m);
 
     if (userdata === null || userdata === undefined) console.log("유저 데이터 가져오기 실패");
     else {

--- a/db/dbconnection.js
+++ b/db/dbconnection.js
@@ -1,6 +1,6 @@
 const mysql = require('mysql');
 const db = mysql.createPool({
-	connectionLimit : 10,
+	connectionLimit : 1000,
 	host: process.env.DB_HOST,
 	user: process.env.DB_USERNAME,
 	password: process.env.DB_PASSWORD,

--- a/main.js
+++ b/main.js
@@ -377,7 +377,6 @@ const isresetWeek = require("./Report/resetcount.js");
 
 (async () => {
     await app.start(process.env.PORT || 3000);
-    sendMsg.dailyMsg();
     schedule.scheduleJob("00 21 * * *", function () {
         sendMsg.dailyMsg();
     });

--- a/main.js
+++ b/main.js
@@ -84,27 +84,14 @@ app.action("action_yes", async ({ body, ack, say, respond }) => {
     // Report 작성 로그 추가
     await Report.addReportLog(body.user.id);
     // 이번주 작성 Report 개수 조회
+    let weekNum = "week" + currWeek;
     db.query(
-        `SET @week = (SELECT period.week
-            FROM period
-            WHERE now() >= period.start_of_week AND now() <= period.end_of_week);
-        SELECT @week;
-        `,
+        `SELECT ${weekNum} FROM user WHERE user_id = "${body.user.id}"`,
         function (error, results, fields) {
             if (error) {
                 console.log(error);
             } else {
-                let weekNum = "week" + results[1][0]["@week"];
-                db.query(
-                    `SELECT ${weekNum} FROM user WHERE user_id = "${body.user.id}"`,
-                    function (error, results, fields) {
-                        if (error) {
-                            console.log(error);
-                        } else {
-                            say(`이번주에 ${results[0][weekNum]} 개의 보고서를 작성하셨습니다.`);
-                        }
-                    }
-                );
+                say(`이번주에 ${results[0][weekNum]} 개의 보고서를 작성하셨습니다.`);
             }
         }
     );
@@ -147,27 +134,14 @@ app.action("action_no", async ({ body, ack, say, respond }) => {
             ]
         });
     }
+    let weekNum = "week" + currWeek;
     db.query(
-        `SET @week = (SELECT period.week
-            FROM period
-            WHERE now() >= period.start_of_week AND now() <= period.end_of_week);
-        SELECT @week;
-        `,
+        `SELECT ${weekNum} FROM user WHERE user_id = "${body.user.id}"`,
         function (error, results, fields) {
             if (error) {
                 console.log(error);
             } else {
-                let weekNum = "week" + results[1][0]["@week"];
-                db.query(
-                    `SELECT ${weekNum} FROM user WHERE user_id = "${body.user.id}"`,
-                    function (error, results, fields) {
-                        if (error) {
-                            console.log(error);
-                        } else {
-                            say(`이번주에 ${results[0][weekNum]} 개의 보고서를 작성하셨습니다.`);
-                        }
-                    }
-                );
+                say(`이번주에 ${results[0][weekNum]} 개의 보고서를 작성하셨습니다.`);
             }
         }
     );


### PR DESCRIPTION
> 경현님이 버튼 쌓아두고 안 클릭한다는 이야기를 들으니 수정할게 자꾸 보이네요 ㅋㅋㅋ

### 문제점
일주일이 지난 메시지의 버튼을 클릭하면 오늘 날짜 기준으로 작성 기록이 정상적으로 저장됩니다. (정상적으로 저장되면 안됨)
이게 되는걸 방지하기 위해  

### 수정사항
* `getPeriod()` 함수 수정 -> 매개변수를 받아서 해당 날짜에 대한 week를 반환하게. 
* 메시지가 처음 온 week, 버튼을 클릭한 week가 다르면 버튼이 `💥timeout`으로 변경되고 응답할 수 없음.  
* week 를 계산해서 변수에 저장하기 때문에, 현재 week를 계산하는 SELECT query는 불필요해져서 제거했습니다.