### PR TITLE
Fix bug : 다중쿼리에서 두번째 쿼리 수정 안되는 문제

### DIFF
--- a/Report/Report.js
+++ b/Report/Report.js
@@ -19,8 +19,7 @@ const addReportLog = (user_id) => {
                         function (error, results, fields) {
                             if (error) {
                                 console.log(error);
-                            }
-                            else {
+                            } else {
                                 resolve(results);
                             }
                         }
@@ -31,31 +30,24 @@ const addReportLog = (user_id) => {
     });
 };
 
-const deleteReportLog = (user_id) => {
-    return new Promise(function(resolve, reject){    
+const deleteReportLog = (user_id, currWeek) => {
+    return new Promise(function(resolve, reject){
+        let weekNum = 'week' + currWeek;
         db.query(
-            `SET @week = (SELECT period.week
-                FROM period
-                WHERE now() >= period.start_of_week AND now() <= period.end_of_week);
-            SELECT @week;
-            `,
+            `UPDATE user SET ${weekNum} = ${weekNum} - 1 
+                WHERE EXISTS( SELECT * from report where date(created_date)=date(now()) AND report.user_id="${user_id}")
+                AND user.user_id="${user_id}";`,
             function (error, results, fields) {
                 if (error) {
                     console.log(error);
                 } else {
-                    let weekNum = 'week' + results[1][0]['@week'];
-                    db.query(
-                        `UPDATE user SET ${weekNum} = ${weekNum} - 1 
-                            WHERE EXISTS( SELECT * from report where date(created_date)=date(now()) AND report.user_id="${user_id}")
-                            AND user.user_id="${user_id}";
-                        DELETE FROM report
-                            WHERE EXISTS( SELECT * from report where date(created_date)=date(now()) AND user_id="${user_id}")
-                            AND user_id="${user_id}";`,
+                    db.query(`DELETE FROM report
+                    WHERE EXISTS( SELECT * from report where date(created_date)=date(now()) AND user_id="${user_id}")
+                    AND user_id="${user_id}";`,
                         function (error, results, fields) {
                             if (error) {
                                 console.log(error);
-                            }
-                            else {
+                            } else {
                                 resolve(results);
                             }
                         }
@@ -64,6 +56,6 @@ const deleteReportLog = (user_id) => {
             }
         );
     });
-};
+}
 
 module.exports = { addReportLog, deleteReportLog };

--- a/Utils/getperiod.js
+++ b/Utils/getperiod.js
@@ -7,7 +7,11 @@ let getPeriod = function (date) {
             FROM period
             WHERE "${date}" >= start_of_week AND "${date}" <= end_of_week;`,
             function(error, results){
-                resolve(results[0].week);
+                if (results[0] !== undefined) {
+                    resolve(results[0].week);
+                } else{
+                    resolve(null);
+                }
             });
         } catch {
             resolve(null);


### PR DESCRIPTION
### 발견한 버그
* 다시 응답하기 누르고 아니오 누르기 반복하면 보고서 작성 개수가 끝도 없이 내려감
![image](https://user-images.githubusercontent.com/13804135/115149530-882fa480-a09f-11eb-91d4-bf09fa48462a.png)

### 원인
* UPDATE 문과 DELETE 문을 같은 쿼리함수에 넣어서 전송했는데, 어떻게 된 일인지 UPDATE 문만 실행되고 DELETE문은 실행되지 않고 있다는 걸 DB에 접속해본 후 알게됨 
* 왜 UPDATE 쿼리만 실행되고 마는지, 아직 정확한 원인이나 비슷한 사례 발견 못함 ㅠㅠㅠㅠㅠㅠㅠㅠㅠ   
[여기](https://github.com/mysqljs/mysql#multiple-statement-queries)에 의하면 첫번째 쿼리에서 오류가 발생하면 두번째 쿼리는 실행되지 않는다고 합니다.. (오류안났는데ㅠㅠ) 그리고 다중쿼리 기능은 아직 실험적이라고 하네요. 
* 그리고 로컬에선 DELETE 도 잘 실행되는데 배포하면 DELETE 가 실행이 안되는 것 같습니다.

### 구현한거
* UPDATE랑 DELETE 분리
* 보고서 작성 기간이 아닐 때 버튼 누르면 DB 쿼리 오류 발생하는 문제 예방하는 코드 추가
    + currWeek 가 null 이면 함수 return 하기 등등

> 소감
>> 괜히 Undo 버튼 넣었나? 버그가 너무 많음 ㅎㅎ   