### PR TITLE
fix: time_zone + 9:00

### DIFF
--- a/Report/resetcount.js
+++ b/Report/resetcount.js
@@ -19,9 +19,10 @@ const resetcount = () => {
 
 let isresetWeek = () => {
     db.query(
-        `SET @week = (SELECT period.week
+        `SET @present = DATE_ADD(NOW(), INTERVAL 9 HOUR);
+        SET @week = (SELECT period.week
             FROM period
-            WHERE now() >= period.start_of_week AND now() <= period.end_of_week);
+            WHERE @present >= period.start_of_week AND @present <= period.end_of_week);
         SELECT @week;
 		`,
         function (error, results, fields) {


### PR DESCRIPTION
isresetWeek에 now() -> now() + 9시간으로 수정했습니다 : )
> ClearDB time_zone이 UTC(영국시간대) 기준이므로, 한국 시간대보다 9시간 늦습니다.
> 이 방법이 임시방편인 것같기도 해서, 추가적인 방법 찾아보려구요: )