### PR TITLE
레포트 작성 기록 저장 로직 변경 + minor fix

### DIFF
--- a/Report/report.js
+++ b/Report/report.js
@@ -1,10 +1,10 @@
 const db = require('../db/dbconnection');
 
-const addReportLog = (user_id, currDate, currWeek) => {
+const addReportLog = (user_id, prevDate, currWeek) => {
     return new Promise(function(resolve, reject){    
         db.query(
             `INSERT INTO report(user_id, created_date, created_week)
-                    VALUES ("${user_id}", "${currDate}", ${currWeek});`,
+                    VALUES ("${user_id}", "${prevDate}", ${currWeek});`,
             function (error, results, fields) {
                 if (error) {
                     console.log(error);
@@ -26,12 +26,12 @@ const addReportLog = (user_id, currDate, currWeek) => {
     });
 };
 
-const deleteReportLog = (user_id, currDate, currWeek) => {
+const deleteReportLog = (user_id, prevDate, currWeek) => {
     return new Promise(function(resolve, reject){
         let weekNum = 'week' + currWeek;
         db.query(
             `UPDATE user SET ${weekNum} = ${weekNum} - 1 
-                WHERE EXISTS( SELECT * from report where date(created_date)=date("${currDate}") AND report.user_id="${user_id}")
+                WHERE EXISTS( SELECT * from report where date(created_date)=date("${prevDate}") AND report.user_id="${user_id}")
                 AND user.user_id="${user_id}";`,
             function (error, results, fields) {
                 if (error) {
@@ -39,7 +39,7 @@ const deleteReportLog = (user_id, currDate, currWeek) => {
                 } else {
                     db.query(`DELETE FROM report
                     WHERE user_id IN (
-                        SELECT temp.user_id from (SELECT user_id FROM report WHERE date(created_date)=date("${currDate}") AND user_id="${user_id}") temp )
+                        SELECT temp.user_id from (SELECT user_id FROM report WHERE date(created_date)=date("${prevDate}") AND user_id="${user_id}") temp )
                     AND user_id="${user_id}";`,
                         function (error, results, fields) {
                             if (error) {

--- a/example.sql
+++ b/example.sql
@@ -1,6 +1,6 @@
 CREATE TABLE `user` (
   `id` int(10) NOT NULL AUTO_INCREMENT,
-  `user_id` varchar(255) NOT NULL,
+  `user_id` varchar(255) NOT NULL UNIQUE,
   `intra_id` varchar(255) DEFAULT NULL,
   `on_off` int(10) DEFAULT 1,
 	`week1` int(10) DEFAULT 0,
@@ -15,6 +15,7 @@ CREATE TABLE `report` (
   `user_id` varchar(255) DEFAULT NULL,
   `created_date` timestamp,
   `created_week` int(10) DEFAULT NULL,
+  FOREIGN KEY (`user_id`) REFERENCES `user`(`user_id`) ON DELETE CASCADE,
   PRIMARY KEY (`report_id`)
 );
 

--- a/main.js
+++ b/main.js
@@ -163,7 +163,6 @@ app.message("!join", async ({ body, say }) => {
             let usersStore = usersData.usersStore;
             let user_id = body.event.user;
             let intra_id = usersStore[user_id].name;
-
             //user테이블에 해당 유저 데이터가 있는지 조회 후 처리
             db.query(
                 `SELECT * FROM user WHERE user_id = "${user_id}"`,
@@ -175,7 +174,30 @@ app.message("!join", async ({ body, say }) => {
                         if (results[0] === undefined) {
                             //유저 정보가 없을 경우 유저 데이터 삽입
                             addUser(user_id, intra_id);
-                            say(`<@${user_id}> 등록 완료`);
+                            say(
+                                {
+                                    blocks: [
+                                        {
+                                            type: "section",
+                                            text: {
+                                                type: "plain_text",
+                                                text: `<@${intra_id}> 등록 완료!`,
+                                            },
+                                        },
+                                        {
+                                            type: "divider",
+                                        },
+                                        {
+                                            type: "section",
+                                            text: {
+                                                type: "mrkdwn",
+                                                text:
+                                                    "`!help` 명령어로 레봇의 기능을 확인할 수 있습니다.",
+                                            },
+                                        },
+                                    ],
+                                }
+                            );
                             console.log("=================new Person=================");
                         } else {
                             //유저 데이터가 이미 존재할 경우 메세지 응답
@@ -207,7 +229,7 @@ app.message("!delete", async ({ body, say }) => {
                         `DELETE FROM user WHERE user_id = "${user_id}"`,
                         (error, results, fileds) => {
                             if (error) console.error(error);
-                            else say(`<@${user_id}> 삭제 완료!`);
+                            else say(`<@${user_id}> 삭제 완료!\n레봇에서 모든 데이터가 삭제됩니다.`);
                         }
                     );
                 } else {
@@ -305,6 +327,23 @@ app.message("!help", async ({ body, say }) => {
                             "`!count`\n: 이번주에 작성한 보고서 개수 확인",
                     },
                 },
+                {
+                    type: "divider",
+                },
+                {
+                    type: "section",
+                    text: {
+                        "type": "mrkdwn",
+                        "text": "<https://github.com/42Helper/42Report_helper|레봇 github 구경하기>"
+                    },
+                },
+                {
+                    type: "section",
+                    text: {
+                        "type": "plain_text",
+                        "text": "문의: @gkim @hjung @hyejshin"
+                    },
+                },
             ],
         });
     } catch (error) {
@@ -343,7 +382,6 @@ const isresetWeek = require("./Report/resetcount.js");
 
 (async () => {
     await app.start(process.env.PORT || 3000);
-    sendMsg.dailyMsg();
     schedule.scheduleJob("00 21 * * *", function () {
         sendMsg.dailyMsg();
     });

--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 const usersDataFunc = require("./Utils/getuserlist.js"); //getuserlist.js에서 start 함수 받아옴
 const schedule = require("node-schedule");
 const sendMsg = require("./Utils/sendmsg.js");
-const Report = require("./Report/Report.js");
+const report = require("./Report/report.js");
 const msgBlocks = require("./Utils/msgBlocks.json");
 const getPeriod = require("./Utils/getperiod.js");
 
@@ -17,7 +17,6 @@ moment.locale("ko");
 
 app.action("action_yes", async ({ body, ack, say, respond }) => {
     await ack();
-    let m = moment();
     let prevDate = moment(body.message.ts * 1000).format('YYYY-MM-DD HH:mm:ss');
     let currDate = moment().format('YYYY-MM-DD HH:mm:ss');
     let prevWeek = await getPeriod(prevDate);
@@ -38,27 +37,6 @@ app.action("action_yes", async ({ body, ack, say, respond }) => {
             ],
         });
         return;
-    } else if (moment(prevDate).isSame(currDate, 'day')){
-        const result = await respond({
-            replace_original: true,
-            blocks: [
-                {
-                    type: "divider",
-                },
-                {
-                    type: "header",
-                    text: {
-                        type: "plain_text",
-                        text: `${m.format("MM/DD (ddd)")}`,
-                        emoji: true,
-                    },
-                },
-                msgBlocks.yesUndo,
-                {
-                    type: "divider",
-                },
-            ],
-        });
     } else {
         const result = await respond({
             replace_original: true,
@@ -70,11 +48,11 @@ app.action("action_yes", async ({ body, ack, say, respond }) => {
                     type: "header",
                     text: {
                         type: "plain_text",
-                        text: `${m.format("MM/DD (ddd)")}`,
+                        text: `${moment(body.message.ts * 1000).format("MM/DD (ddd)")}`,
                         emoji: true,
                     },
                 },
-                msgBlocks.yesOnly,
+                msgBlocks.yesUndo,
                 {
                     type: "divider",
                 },
@@ -82,7 +60,7 @@ app.action("action_yes", async ({ body, ack, say, respond }) => {
         });
     };
     // Report 작성 로그 추가
-    await Report.addReportLog(body.user.id, currDate, currWeek);
+    await report.addReportLog(body.user.id, prevDate, currWeek);
     // 이번주 작성 Report 개수 조회
     let weekNum = "week" + currWeek;
     db.query(
@@ -119,21 +97,14 @@ app.action("action_no", async ({ body, ack, say, respond }) => {
             ],
         });
         return;
-    } else if (moment(prevDate).isSame(currDate, 'day')){
+    } else {
         const result = await respond({
             replace_original: true,
             blocks: [
                 msgBlocks.noUndo
             ],
         });
-    } else {
-        const result = await respond({
-            replace_original: true,
-            blocks: [
-                msgBlocks.noOnly
-            ]
-        });
-    }
+    };
     let weekNum = "week" + currWeek;
     db.query(
         `SELECT ${weekNum} FROM user WHERE user_id = "${body.user.id}"`,
@@ -151,12 +122,15 @@ app.action("action_undo", async ({ body, ack, say, respond }) => {
     await ack();
     let prevDate = moment(body.message.ts * 1000).format('YYYY-MM-DD HH:mm:ss');
     let currDate = moment().format('YYYY-MM-DD HH:mm:ss');
+    let prevWeek = await getPeriod(prevDate);
     let currWeek = await getPeriod(currDate);
     if (currWeek === null){
         say("보고서 작성 기간이 아닙니다.");
         return ;
-    }
-    if (moment(prevDate).isSame(currDate, 'day')){
+    } else if (prevWeek !== currWeek) {
+        say("한 주가 지난 후에는 응답을 수정하실 수 없습니다.");
+        return ;
+    } else {
         const result = await respond({
             replace_original: true,
             blocks: [
@@ -171,12 +145,9 @@ app.action("action_undo", async ({ body, ack, say, respond }) => {
                 msgBlocks.btnYesNo
             ],
         });
-    } else {
-        say("해당 날짜가 지난 후에는 응답을 수정하실 수 없습니다.");
-        return ;
     }
     // 이전에 YES를 누른 후 undo를 눌렀을 경우에만 이번주 작성 Report 개수 1 감소
-    await Report.deleteReportLog(body.user.id, currDate, currWeek);
+    await report.deleteReportLog(body.user.id, prevDate, currWeek);
 });
 
 const addUser = require("./User/saveDB.js");
@@ -372,6 +343,7 @@ const isresetWeek = require("./Report/resetcount.js");
 
 (async () => {
     await app.start(process.env.PORT || 3000);
+    sendMsg.dailyMsg();
     schedule.scheduleJob("00 21 * * *", function () {
         sendMsg.dailyMsg();
     });


### PR DESCRIPTION
1. 하루가 지나면 수정을 못하는게 불편하다는 후기가 있어서  
하루가 지나도 응답을 수정할 수 있게 변경하였습니다. 
버튼을 누른 날짜(`currDate`)가 아닌, 메시지가 도착한 날짜(`prevDate`)를 기준으로 저장하여,
다시 응답하기를 누를 때도 푸시알림 메시지가 도착한 날짜를 기준으로 검색해서 delete 합니다.

+) (별거아닌) side effect 
최초에 Yes를 누르면 나오는 메시지에 원래는 버튼 누른 날짜가 표시됐는데, 이제 메시지 도착한 날짜로 표시됨.

2. `!delete` 할 때 report 로그에 있는 기록도 다 지워져야 다음에 다시 `!join` 할 때 깔끔할 것 같아서 
user 테이블의 user_id 필드를 report 테이블의 user_id 필드의 Foreign Key로 설정하였습니다.

3. 왜 문의할 수 있는 경로가 없냐는 피드백을 받아서
`!help` 명령어에 깃허브 주소와 저희 인트라아이디도 적어뒀습니다.